### PR TITLE
Disable Prompt to Install

### DIFF
--- a/Windows/MachineSetup.bat
+++ b/Windows/MachineSetup.bat
@@ -60,7 +60,6 @@ IF ERRORLEVEL 0 (
 
 ECHO "Installing Chocolatey"
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
-
 choco feature enable -n allowGlobalConfirmation
 
 ECHO "Installing Git"
@@ -71,5 +70,10 @@ CALL cinst notepadplusplus
 
 ECHO "Installing 7zip"
 CALL cinst 7zip
+
+ECHO "Installing Visual Studio Components"
+CALL cinst VisualStudio2013Ultimate
+CALL cinst VS2013.4
+CALL cinst resharper
 
 ECHO "Script complete. Restart now."

--- a/Windows/MachineSetup.bat
+++ b/Windows/MachineSetup.bat
@@ -71,6 +71,9 @@ CALL cinst notepadplusplus
 ECHO "Installing 7zip"
 CALL cinst 7zip
 
+ECHO "Installing Classic Shell"
+CALL cinst classic-shell -installArgs ADDLOCAL=ClassicStartMenu
+
 ECHO "Installing Visual Studio Components"
 IF NOT EXIST "%PROGRAMFILES(X86)%\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe" (
    ECHO Installing Visual Studio 2015

--- a/Windows/MachineSetup.bat
+++ b/Windows/MachineSetup.bat
@@ -76,4 +76,8 @@ CALL cinst VisualStudio2013Ultimate
 CALL cinst VS2013.4
 CALL cinst resharper
 
+REM This patch is for VS2013 Update 4
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$dl=New-Object Net.WebClient;$dl.DownloadFile('http://download.microsoft.com/download/3/8/F/38F49568-2B7F-43B9-A316-ABF46F5058F2/VS12-KB3018885.exe', $env:TEMP + '\VS12-KB3018885.exe');"
+CALL "%TEMP%\VS12-KB3018885.exe" /Silent /NoRestart
+
 ECHO "Script complete. Restart now."

--- a/Windows/MachineSetup.bat
+++ b/Windows/MachineSetup.bat
@@ -22,7 +22,7 @@ IF ERRORLEVEL 0 (
 	REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarSmallIcons" /t REG_DWORD /d 1 /f
 )
 
-ECHO "Remove Windows Store Apps icon from the Taskbar"
+ECHO "Don't show Windows Store Apps on the Taskbar"
 REG QUERY "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "StoreAppsOnTaskbar" | Find "0x0"
 IF ERRORLEVEL 0 (
 	REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "StoreAppsOnTaskbar" /t REG_DWORD /d 0 /f

--- a/Windows/MachineSetup.bat
+++ b/Windows/MachineSetup.bat
@@ -72,12 +72,10 @@ ECHO "Installing 7zip"
 CALL cinst 7zip
 
 ECHO "Installing Visual Studio Components"
-CALL cinst VisualStudio2013Ultimate
-CALL cinst VS2013.4
+IF NOT EXIST "%PROGRAMFILES(X86)%\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe" (
+   ECHO Installing Visual Studio 2015
+   CALL cinst VisualStudio2015Enterprise -force
+)
 CALL cinst resharper
-
-REM This patch is for VS2013 Update 4
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$dl=New-Object Net.WebClient;$dl.DownloadFile('http://download.microsoft.com/download/3/8/F/38F49568-2B7F-43B9-A316-ABF46F5058F2/VS12-KB3018885.exe', $env:TEMP + '\VS12-KB3018885.exe');"
-CALL "%TEMP%\VS12-KB3018885.exe" /Silent /NoRestart
 
 ECHO "Script complete. Restart now."

--- a/Windows/MachineSetup.bat
+++ b/Windows/MachineSetup.bat
@@ -61,6 +61,8 @@ IF ERRORLEVEL 0 (
 ECHO "Installing Chocolatey"
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
 
+choco feature enable -n allowGlobalConfirmation
+
 ECHO "Installing Git"
 CALL cinst git
 


### PR DESCRIPTION
Disable Chocolatey's prompting when new packages are installed. This was added to Chocolatey in Version 9.9.